### PR TITLE
add see all option for exercise window

### DIFF
--- a/src/app/browser/browser-window/browser-window.component.css
+++ b/src/app/browser/browser-window/browser-window.component.css
@@ -1,7 +1,7 @@
 .frame {
   border: 1px solid #dddddd;
   padding: 10px;
-  margin-top: -3px;
+  margin-top: 0px;
   width: 100%;
   background-color: #fff;
 }

--- a/src/app/browser/console-window/console-window.component.css
+++ b/src/app/browser/console-window/console-window.component.css
@@ -5,12 +5,13 @@
 }
 
 .frame {
-
+  border: 1px solid #dddddd;
   padding: 10px;
-  margin-top: -3px;
+  margin-top: 0px;
   width: 100%;
   background-color: #fff;
 }
+
 
 .img-full {
   width: 100%;

--- a/src/app/exercise/tests/tests.component.html
+++ b/src/app/exercise/tests/tests.component.html
@@ -1,9 +1,14 @@
-<div *ngFor="let test of tests; trackBy: trackTest" class="test-panel" title="{{test.result}}">
-  <slides-test-description [title]="getTitle(test)"
-                           [file]="getTestFile(test)"
-                           [pass]="test.pass"
-                           [class.first-unsolved]="isFirstUnsolved(test)"
-                           (onSelectFile)="onSelectFile.emit($event)"
-  ></slides-test-description>
-  <div class="result" *ngIf="isFirstUnsolved(test)">{{test.result}}</div>
-</div>
+<ng-container *ngFor="let test of tests; let i=index; trackBy: trackTest">
+  <div *ngIf="seeAll || i==indexOfFirstUnsolved()" class="test-panel" title="{{test.result}}">
+    <slides-test-description [title]="getTitle(test)"
+                            [file]="getTestFile(test)"
+                            [pass]="test.pass"
+                            [class.first-unsolved]="isFirstUnsolved(test)"
+                            (onSelectFile)="onSelectFile.emit($event)"
+    ></slides-test-description>
+    <div class="result" *ngIf="isFirstUnsolved(test)">{{test.result}}</div>
+  </div>
+</ng-container>
+<div *ngIf="tests!=null && tests.length>1" style="margin-top: 10px; margin-left: 20px;">
+  <a href="#" (click)="toggleSeeAll($event)">{{seeAll ? "see only next step": "see all steps"}}</a>
+</div> 

--- a/src/app/exercise/tests/tests.component.ts
+++ b/src/app/exercise/tests/tests.component.ts
@@ -18,6 +18,8 @@ export class TestsComponent {
   @Output()
   public onSelectFile: EventEmitter<FileConfig> = new EventEmitter<FileConfig>();
 
+  seeAll = false;
+
   constructor(private sanitizer: DomSanitizer) {
   };
 
@@ -36,5 +38,14 @@ export class TestsComponent {
 
   isFirstUnsolved(test) {
     return this.tests.find(t => !t.pass) === test;
+  }
+
+  indexOfFirstUnsolved() {
+    return this.tests.findIndex(t => !t.pass);
+  }
+
+  toggleSeeAll(event) {
+    this.seeAll = !this.seeAll;
+    event.preventDefault();
   }
 }


### PR DESCRIPTION
In exercise added option for see all. By default shows only the next action. Toggle link added for see all or just the next action

**Default View**
![image](https://user-images.githubusercontent.com/28489640/26859402-7dce550c-4b05-11e7-9ba6-bbc78ebde2f4.png)

**All Tests**
![image](https://user-images.githubusercontent.com/28489640/26859415-8c493070-4b05-11e7-835c-5f1099407682.png)

See all option is available only when more than one test is available.

Also fixed issue with console window and browser window. The top section of the window was not visible completely.
 