### PR TITLE
add codeclimate badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AngularPresentation
 
 [![Join the chat at https://gitter.im/AngularNYC/angular-presentation](https://badges.gitter.im/AngularNYC/angular-presentation.svg)](https://gitter.im/AngularNYC/angular-presentation?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+<a href="https://codeclimate.com/github/nycJSorg/angular-presentation/coverage"><img src="https://codeclimate.com/github/nycJSorg/angular-presentation/badges/coverage.svg" /></a>
+
 Demo: [Demo](https://angular-presentation.firebaseapp.com/)
 
 ## Project structure


### PR DESCRIPTION
if anyone also wanted to know, idk how to get there via the gui but figured out that going to [/badges](https://codeclimate.com/github/nycJSorg/angular-presentation/badges) works