### PR TITLE
fix for back button functionality

### DIFF
--- a/src/app/presentation/slides-routing/slides-routing.directive.ts
+++ b/src/app/presentation/slides-routing/slides-routing.directive.ts
@@ -1,6 +1,7 @@
 import { ActivatedRoute, Router } from '@angular/router';
 import { Directive, EventEmitter, HostListener, OnInit, Output } from '@angular/core';
 import { PresentationComponent } from '../presentation/presentation.component';
+import { values } from  'lodash';
 
 @Directive({
   // tslint:disable-next-line:all TODO: Fix linter warnings on the selector and delete this comment.
@@ -15,7 +16,13 @@ export class SlidesRoutingDirective implements OnInit {
   @Output() change = new EventEmitter();
 
   constructor(private router: Router, private route: ActivatedRoute, private presentation: PresentationComponent) {
+    this.route.params.subscribe( params => {
+      let index = values(this.ids).findIndex(id => id === params.id);
 
+      if(index >= 0){
+        presentation.goToSlide(index);
+      }
+    })
   }
 
   @HostListener('onSlideAdded', ['$event']) slideAdded(value: { index: number, id?: string }) {

--- a/src/app/presentation/slides-routing/slides-routing.directive.ts
+++ b/src/app/presentation/slides-routing/slides-routing.directive.ts
@@ -1,7 +1,7 @@
 import { ActivatedRoute, Router } from '@angular/router';
 import { Directive, EventEmitter, HostListener, OnInit, Output } from '@angular/core';
 import { PresentationComponent } from '../presentation/presentation.component';
-import { values } from  'lodash';
+import { values } from 'lodash';
 
 @Directive({
   // tslint:disable-next-line:all TODO: Fix linter warnings on the selector and delete this comment.
@@ -19,10 +19,10 @@ export class SlidesRoutingDirective implements OnInit {
     this.route.params.subscribe( params => {
       const index = values(this.ids).findIndex(id => id === params.id);
 
-      if(index >= 0){
+      if (index >= 0) {
         presentation.goToSlide(index);
       }
-    })
+    });
   }
 
   @HostListener('onSlideAdded', ['$event']) slideAdded(value: { index: number, id?: string }) {

--- a/src/app/presentation/slides-routing/slides-routing.directive.ts
+++ b/src/app/presentation/slides-routing/slides-routing.directive.ts
@@ -17,7 +17,7 @@ export class SlidesRoutingDirective implements OnInit {
 
   constructor(private router: Router, private route: ActivatedRoute, private presentation: PresentationComponent) {
     this.route.params.subscribe( params => {
-      let index = values(this.ids).findIndex(id => id === params.id);
+      const index = values(this.ids).findIndex(id => id === params.id);
 
       if(index >= 0){
         presentation.goToSlide(index);


### PR DESCRIPTION
#493  had to watch params change in the route and trigger presentation `goToSlide`. 

Not sure why `Object.values( obj )` did not work, so I used lodash to get array of values instead.