### PR TITLE
Normalize feedback data to include Firebase key

### DIFF
--- a/libs/feedback/src/lib/feedback.service.ts
+++ b/libs/feedback/src/lib/feedback.service.ts
@@ -6,6 +6,13 @@ import { Observable } from 'rxjs';
 import { getRef } from '@angular/fire/database/utils';
 import { map, switchMap } from 'rxjs/operators';
 
+function normalize(feedback: Array<any>) {
+  return feedback.map(item => ({
+    ...(item.payload && item.payload.val()),
+    key: item.key
+  }));
+}
+
 @Injectable()
 export class FeedbackService {
   private repo$: AngularFireList<any>;
@@ -23,7 +30,8 @@ export class FeedbackService {
       switchMap(url => {
         return this.database
           .list('/feedback', ref => ref.orderByChild('href').equalTo(url))
-          .valueChanges();
+          .snapshotChanges()
+          .pipe(map(normalize));
       }),
       map((items: Message[]) => items.filter(item => !item.isDone))
     );


### PR DESCRIPTION
Currently, we use [`valueChanges()`](https://github.com/angular/angularfire2/blob/master/docs/rtdb/lists.md#valuechanges) method of AngularFireDatabase to retrieve  data in the feedback widget.
It strips out the `key` property of firebase objects and doesn't permit any data manipulation.

One of the examples of this limitation is #862 , where the `key` property is necessary to update the `isDone` property of a message.

This PR fixes that problem by using a more powerful [`snapshotChanges()`](https://github.com/angular/angularfire2/blob/master/docs/rtdb/lists.md#snapshotchanges) method, which gives access to the `key` property.